### PR TITLE
Add github provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
 	"require": {
 		"mediawiki/oauthclient": "*",
-		"league/oauth2-facebook": "^2.0"
+		"league/oauth2-facebook": "^2.0",
+                "league/oauth2-github": "^2.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "38.0.0",

--- a/src/AuthenticationProvider/GithubAuth.php
+++ b/src/AuthenticationProvider/GithubAuth.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Copyright 2020 Marijn van Wezel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace WSOAuth\AuthenticationProvider;
+
+use League\OAuth2\Client\Provider\Github;
+use MediaWiki\User\UserIdentity;
+
+class GithubAuth implements AuthProvider {
+	/**
+	 * @var Github
+	 */
+	private $provider;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function __construct( string $clientId, string $clientSecret, ?string $authUri, ?string $redirectUri ) {
+		$this->provider = new Github( [
+			'clientId' => $clientId,
+			'clientSecret' => $clientSecret,
+			'redirectUri' => $redirectUri,
+		] );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function login( ?string &$key, ?string &$secret, ?string &$authUrl ): bool {
+		$authUrl = $this->provider->getAuthorizationUrl( [
+			'scope' => [ 'user' ]
+		] );
+
+		$secret = $this->provider->getState();
+
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function logout( UserIdentity &$user ): void {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getUser( string $key, string $secret, &$errorMessage ) {
+		if ( !isset( $_GET['code'] ) ) {
+			return false;
+		}
+
+		if ( !isset( $_GET['state'] ) || empty( $_GET['state'] ) || ( $_GET['state'] !== $secret ) ) {
+			return false;
+		}
+
+		try {
+			$token = $this->provider->getAccessToken( 'authorization_code', [ 'code' => $_GET['code'] ] );
+			$user = $this->provider->getResourceOwner( $token );
+
+			return [
+				'name' => $user->getNickname(),
+				'realname' => $user->getName(),
+				'email' => $user->getEmail()
+			];
+		} catch ( \Exception $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function saveExtraAttributes( int $id ): void {
+	}
+}

--- a/src/WSOAuth.php
+++ b/src/WSOAuth.php
@@ -26,6 +26,7 @@ use MediaWiki\User\UserNameUtils;
 use RequestContext;
 use User;
 use WSOAuth\AuthenticationProvider\AuthProvider;
+use WSOAuth\AuthenticationProvider\GithubAuth;
 use WSOAuth\AuthenticationProvider\FacebookAuth;
 use WSOAuth\AuthenticationProvider\MediaWikiAuth;
 use WSOAuth\Exception\ContinuationException;
@@ -44,7 +45,8 @@ class WSOAuth extends PluggableAuth {
 	public const MAPPING_TABLE_NAME = 'wsoauth_multiauth_mappings';
 	public const DEFAULT_AUTH_PROVIDERS = [
 		"mediawiki" => MediaWikiAuth::class,
-		"facebook" => FacebookAuth::class
+		"facebook" => FacebookAuth::class,
+                "github" => GithubAuth::class
 	];
 
 	/**


### PR DESCRIPTION
Add GitHub as a default provider, using the PHP League's OAuth2 client for GitHub.  The GithubAuth class is based on the existing FacebookAuth class, with minor edits.